### PR TITLE
Small edits to remove notes from R CMD check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .DS_Store
 .Rprofile
 *.Rcheck
-.Rbuildignore
 *.Rproj
 renv*
 *tar.gz

--- a/R/iidda/.Rbuildignore
+++ b/R/iidda/.Rbuildignore
@@ -1,0 +1,5 @@
+^LICENSE\.md$
+git ^Makefile$
+^config\.json$
+^misc$
+^install$

--- a/R/iidda/DESCRIPTION
+++ b/R/iidda/DESCRIPTION
@@ -7,12 +7,12 @@ Maintainer: Steve Walker <swalk@mcmaster.ca>
 Depends: 
   dplyr, 
   tidyr, 
-  memoise, 
   jsonlite, 
   tibble
 Imports: 
   lubridate,
   tidyxl, 
+  memoise, 
   iidda.list
 Description: Part of an open toolchain for processing infectious disease datasets available through the IIDDA data repository.
 License: GPL (>= 3)


### PR DESCRIPTION
Moved **memoise** to `Imports` from `Depends`, fiddled with `.Rbuildignore` stuff. Fixes #20 